### PR TITLE
Multi-camera support: camera can be selected with serial number. Topics/nodes/TF names composed with camera base name. 

### DIFF
--- a/kinect2_bridge/include/kinect2_definitions.h
+++ b/kinect2_bridge/include/kinect2_definitions.h
@@ -19,25 +19,24 @@
 #ifndef __KINECT2_DEFINITIONS_H__
 #define __KINECT2_DEFINITIONS_H__
 
-#define K2_TOPIC_BASE          "/kinect2_head/"
-#define K2_TF_RGB_FRAME        "/head_mount_kinect2_rgb_optical_frame"
-#define K2_TF_IR_FRAME         "/head_mount_kinect2_ir_optical_frame"
+#define K2_TF_RGB_FRAME        "_rgb_optical_frame"
+#define K2_TF_IR_FRAME         "_ir_optical_frame"
 
-#define K2_TOPIC_IMAGE_IR      K2_TOPIC_BASE "ir/"
-#define K2_TOPIC_RECT_IR       K2_TOPIC_BASE "ir_rect/"
+#define K2_TOPIC_IMAGE_IR      "ir/"
+#define K2_TOPIC_RECT_IR       "ir_rect/"
 
-#define K2_TOPIC_IMAGE_COLOR   K2_TOPIC_BASE "rgb/"
-#define K2_TOPIC_RECT_COLOR    K2_TOPIC_BASE "rgb_rect/"
-#define K2_TOPIC_LORES_COLOR   K2_TOPIC_BASE "rgb_lowres/"
+#define K2_TOPIC_IMAGE_COLOR   "rgb/"
+#define K2_TOPIC_RECT_COLOR    "rgb_rect/"
+#define K2_TOPIC_LORES_COLOR   "rgb_lowres/"
 
-#define K2_TOPIC_IMAGE_MONO    K2_TOPIC_BASE "mono/"
-#define K2_TOPIC_RECT_MONO     K2_TOPIC_BASE "mono_rect/"
-#define K2_TOPIC_LORES_MONO    K2_TOPIC_BASE "mono_lowres/"
+#define K2_TOPIC_IMAGE_MONO    "mono/"
+#define K2_TOPIC_RECT_MONO     "mono_rect/"
+#define K2_TOPIC_LORES_MONO    "mono_lowres/"
 
-#define K2_TOPIC_IMAGE_DEPTH   K2_TOPIC_BASE "depth/"
-#define K2_TOPIC_RECT_DEPTH    K2_TOPIC_BASE "depth_rect/"
-#define K2_TOPIC_LORES_DEPTH   K2_TOPIC_BASE "depth_lowres/"
-#define K2_TOPIC_HIRES_DEPTH   K2_TOPIC_BASE "depth_highres/"
+#define K2_TOPIC_IMAGE_DEPTH   "depth/"
+#define K2_TOPIC_RECT_DEPTH    "depth_rect/"
+#define K2_TOPIC_LORES_DEPTH   "depth_lowres/"
+#define K2_TOPIC_HIRES_DEPTH   "depth_highres/"
 
 #define K2_TOPIC_RAW           "image"
 #define K2_TOPIC_IMAGE         "image"

--- a/kinect2_bridge/launch/include/kinect2_frames.launch
+++ b/kinect2_bridge/launch/include/kinect2_frames.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="publish_frame"   />
+  <arg name="publish_frame" default="false" />
   <arg name="camera" default="head_mount_kinect2" />
   <arg name="tf_prefix" default="" />
                     

--- a/kinect2_bridge/launch/kinect2_bridge.launch
+++ b/kinect2_bridge/launch/kinect2_bridge.launch
@@ -1,33 +1,37 @@
 <launch>
   <arg name="publish_frame" default="false" />
+  <arg name="sensor_id" default=""/> 
+  <arg name="sensor_name" default="kinect2_head" />
 
   <include file="$(find kinect2_bridge)/launch/include/kinect2_frames.launch">
     <arg name="publish_frame" value="$(arg publish_frame)" />
+    <arg name="camera" value="$(arg sensor_name)"/>
   </include>
 
-  <node name="kinect2_bridge" pkg="kinect2_bridge" type="kinect2_bridge"
-        respawn="true"
-        output="screen"/>
+  <node name="$(arg sensor_name)_kinect2_bridge" pkg="kinect2_bridge" type="kinect2_bridge" respawn="true" output="screen">
+    <param name="sensor_name" value="$(arg sensor_name)"/>
+    <param name="sensor_id" value="$(arg sensor_id)" type="str" />
+  </node>
 
   <!-- low resolution point cloud (960 x 540) -->
-  <node pkg="nodelet" type="nodelet" name="points_xyzrgb_lowres"
+  <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)_points_xyzrgb_lowres"
         args="standalone depth_image_proc/point_cloud_xyzrgb"
         respawn="false">
-    <remap from="rgb/camera_info"             to="/kinect2_head/rgb_lowres/camera_info" />
-    <remap from="rgb/image_rect_color"        to="/kinect2_head/rgb_lowres/image" />
-    <remap from="depth_registered/image_rect" to="/kinect2_head/depth_lowres/image" />
-    <remap from="depth_registered/points"     to="/kinect2_head/depth_lowres/points" />
+    <remap from="rgb/camera_info"             to="/$(arg sensor_name)/rgb_lowres/camera_info" />
+    <remap from="rgb/image_rect_color"        to="/$(arg sensor_name)/rgb_lowres/image" />
+    <remap from="depth_registered/image_rect" to="/$(arg sensor_name)/depth_lowres/image" />
+    <remap from="depth_registered/points"     to="/$(arg sensor_name)/depth_lowres/points" />
     <param name="queue_size" type="int" value="2" />
   </node>
 
   <!-- high resolution point cloud (1920 x 1080) -->
-  <node pkg="nodelet" type="nodelet" name="points_xyzrgb_highres"
+  <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)_points_xyzrgb_highres"
         args="standalone depth_image_proc/point_cloud_xyzrgb"
         respawn="false">
-    <remap from="rgb/camera_info"             to="/kinect2_head/rgb_rect/camera_info" />
-    <remap from="rgb/image_rect_color"        to="/kinect2_head/rgb_rect/image" />
-    <remap from="depth_registered/image_rect" to="/kinect2_head/depth_highres/image" />
-    <remap from="depth_registered/points"     to="/kinect2_head/depth_highres/points" />
+    <remap from="rgb/camera_info"             to="/$(arg sensor_name)/rgb_rect/camera_info" />
+    <remap from="rgb/image_rect_color"        to="/$(arg sensor_name)/rgb_rect/image" />
+    <remap from="depth_registered/image_rect" to="/$(arg sensor_name)/depth_highres/image" />
+    <remap from="depth_registered/points"     to="/$(arg sensor_name)/depth_highres/points" />
     <param name="queue_size" type="int" value="2" />
   </node>
 </launch>

--- a/registration_viewer/src/viewer.cpp
+++ b/registration_viewer/src/viewer.cpp
@@ -533,14 +533,17 @@ void help(const std::string &path)
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "viewer");
-
+  ros::NodeHandle nh("~");
+  
+  std::string cameraName = "kinect2_head";  
+  
   if(!ros::ok())
   {
     return 0;
   }
 
-  std::string topicColor = K2_TOPIC_LORES_COLOR K2_TOPIC_RAW;
-  std::string topicDepth = K2_TOPIC_LORES_DEPTH K2_TOPIC_RAW;
+  std::string topicColor = "/" + cameraName + "/" + K2_TOPIC_LORES_COLOR K2_TOPIC_RAW;
+  std::string topicDepth = "/" + cameraName + "/" + K2_TOPIC_LORES_DEPTH K2_TOPIC_RAW;
   bool useExact = true;
   bool useCompressed = true;
   Receiver::Mode mode = Receiver::CLOUD;
@@ -555,22 +558,26 @@ int main(int argc, char **argv)
       ros::shutdown();
       return 0;
     }
+    else if(param == "-name")
+    {
+      cameraName = argv[++i];
+	}
     else if(param == "-kinect2")
     {
-      topicColor = K2_TOPIC_LORES_COLOR K2_TOPIC_RAW;
-      topicDepth = K2_TOPIC_LORES_DEPTH K2_TOPIC_RAW;
+      topicColor = "/" + cameraName + "/" + K2_TOPIC_LORES_COLOR K2_TOPIC_RAW;
+      topicDepth = "/" + cameraName + "/" + K2_TOPIC_LORES_DEPTH K2_TOPIC_RAW;
       useExact = true;
     }
     else if(param == "-kinect2hd")
     {
-      topicColor = K2_TOPIC_RECT_COLOR K2_TOPIC_RAW;
-      topicDepth = K2_TOPIC_HIRES_DEPTH K2_TOPIC_RAW;
+      topicColor = "/" + cameraName + "/" + K2_TOPIC_RECT_COLOR K2_TOPIC_RAW;
+      topicDepth = "/" + cameraName + "/" + K2_TOPIC_HIRES_DEPTH K2_TOPIC_RAW;
       useExact = true;
     }
     else if(param == "-kinect2ir")
     {
-      topicColor = K2_TOPIC_RECT_IR K2_TOPIC_RAW;
-      topicDepth = K2_TOPIC_RECT_DEPTH K2_TOPIC_RAW;
+      topicColor = "/" + cameraName + "/" + K2_TOPIC_RECT_IR K2_TOPIC_RAW;
+      topicDepth = "/" + cameraName + "/" + K2_TOPIC_RECT_DEPTH K2_TOPIC_RAW;
       useExact = true;
     }
     else if(param == "-color" && i + 1 < (size_t)argc)
@@ -605,6 +612,8 @@ int main(int argc, char **argv)
       mode = Receiver::BOTH;
     }
   }
+  
+  nh.param("sensor_name", cameraName, cameraName);
 
   std::cout << "topic color: " << topicColor << std::endl;
   std::cout << "topic depth: " << topicDepth << std::endl;


### PR DESCRIPTION
Now the camera base name can be passed via launch file and a particular camera can be selected by passing the serial number in the launch files. Topics and TF frames are also renamed according to the camera base name.