### PR TITLE
Add missing dependency on tf.

### DIFF
--- a/kinect2_bridge/CMakeLists.txt
+++ b/kinect2_bridge/CMakeLists.txt
@@ -21,7 +21,7 @@ ENDIF()
 
 find_package(freenect2 REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rostime std_msgs sensor_msgs nodelet cv_bridge compressed_depth_image_transport kinect2_registration)
+find_package(catkin REQUIRED COMPONENTS roscpp rostime tf std_msgs sensor_msgs nodelet cv_bridge compressed_depth_image_transport kinect2_registration)
 
 ## System dependencies are found with CMake's conventions
 find_package(OpenCV REQUIRED)

--- a/kinect2_bridge/package.xml
+++ b/kinect2_bridge/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>rostime</build_depend>
+  <build_depend>tf</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>message_filters</build_depend>
@@ -23,6 +24,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>
+  <run_depend>tf</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>compressed_depth_image_transport</run_depend>


### PR DESCRIPTION
`kinect2_bridge` uses `tf` but does not declare it as dependency. That gave linking errors. Strangely enough no missing includes during compilation. Either way, this PR adds the dependency in `package.xml` and `CMakeLists.txt`.