### PR TITLE
Use qualified std::isnan.

### DIFF
--- a/kinect2_viewer/src/viewer.cpp
+++ b/kinect2_viewer/src/viewer.cpp
@@ -447,7 +447,7 @@ private:
       {
         register const float depthValue = *itD / 1000.0f;
         // Check for invalid measurements
-        if(isnan(depthValue) || depthValue <= 0.001)
+        if(std::isnan(depthValue) || depthValue <= 0.001)
         {
           // not valid
           itP->x = itP->y = itP->z = badPoint;


### PR DESCRIPTION
On a recently updated arch system, the `kinect2_viewer` fails to compile because `isnan` is not defined in global scope. The header `<cmath>` defines it in the `std` namespace [1].

`std::isnan` is only available since C++11, but if I'm not mistaken the project already requires C++11 so that should not be a problem.

This PR uses the fully qualified name `std::isnan` to fix the compilation issue.

[1] http://en.cppreference.com/w/cpp/numeric/math/isnan