### PR TITLE
Fix image encodings to comply with ROS

### DIFF
--- a/kinect2_bridge/src/kinect2_bridge.cpp
+++ b/kinect2_bridge/src/kinect2_bridge.cpp
@@ -1335,7 +1335,7 @@ private:
     case DEPTH_SD_RECT:
     case DEPTH_HD:
     case DEPTH_QHD:
-      msgImage.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+      msgImage.encoding = sensor_msgs::image_encodings::MONO16;
       break;
     case COLOR_SD_RECT:
     case COLOR_HD:
@@ -1348,7 +1348,7 @@ private:
     case MONO_HD_RECT:
     case MONO_QHD:
     case MONO_QHD_RECT:
-      msgImage.encoding = sensor_msgs::image_encodings::TYPE_8UC1;
+      msgImage.encoding = sensor_msgs::image_encodings::MONO8;
       break;
     case COUNT:
       return;


### PR DESCRIPTION
In order to use standard ROS image tools with the published images they should have the correct ROS encoding (not OpenCV). For the full list of definitions see [here](http://docs.ros.org/jade/api/sensor_msgs/html/image__encodings_8h_source.html).
