### PR TITLE
PCL config for ROS Kinetic

### DIFF
--- a/kinect2_viewer/CMakeLists.txt
+++ b/kinect2_viewer/CMakeLists.txt
@@ -24,7 +24,11 @@ find_package(catkin REQUIRED COMPONENTS roscpp rostime std_msgs sensor_msgs mess
 ## System dependencies are found with CMake's conventions
 find_package(OpenCV REQUIRED)
 find_package(OpenMP)
-find_package(PCL REQUIRED)
+find_package(PCL 1.7 REQUIRED)
+
+if(NOT "${PCL_LIBRARIES}" STREQUAL "")
+  list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+endif()
 
 if(OPENMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")

--- a/kinect2_viewer/package.xml
+++ b/kinect2_viewer/package.xml
@@ -21,6 +21,7 @@
   <build_depend>kinect2_bridge</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>cv_bridge</build_depend><!-- Depend on cv_bridge instead of libopencv-dev to support ROS Hydro.-->
+  <build_depend>libproj-dev</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
I have installed iai_kinect2 on ROS Kinetic (latest version). I compiled and worked fine with just small PCL configuration. Since in Kinetic cv_bridge depends on OpenCV 3 there is no issue with compiling.