### PR TITLE
use different cmake variable for eigen include dir

### DIFF
--- a/kinect2_registration/CMakeLists.txt
+++ b/kinect2_registration/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 if(Eigen3_FOUND)
   message(STATUS "CPU based depth registration enabled")
-  include_directories(${EIGEN3_INCLUDE_DIRS})
+  include_directories(${EIGEN3_INCLUDE_DIR})
   set(DEPTH_REG_CPU ON)
   add_definitions(-DDEPTH_REG_CPU)
 else()


### PR DESCRIPTION
Eigen3.2's upstream FindEigen3.cmake specifies only EIGEN3_INCLUDE_DIR, not
EIGEN3_INCLUDE_DIRS: 
https://bitbucket.org/eigen/eigen/src/cafa6d909f409f4ec33070ebf991a77e7b747dc1/cmake/FindEigen3.cmake?at=default&fileviewer=file-view-default#FindEigen3.cmake-10

Eigen3.3-beta provides an Eigen3Config that defines EIGEN3_INCLUDE_DIRS AND
_DIR, but that's still beta, even though Ubuntu introduced it in xenial
already. So to stay backwards compatible, _INCLUDE_DIR should be used.