### PR TITLE
allow configuring screen output

### DIFF
--- a/kinect2_bridge/launch/kinect2_bridge.launch
+++ b/kinect2_bridge/launch/kinect2_bridge.launch
@@ -25,6 +25,7 @@
   <arg name="use_machine"       default="true"/>
   <arg name="respawn"           default="true"/>
   <arg name="use_nodelet"       default="true"/>
+  <arg name="output"            default="screen"/>
 
   <machine name="localhost" address="localhost" if="$(arg use_machine)"/>
 
@@ -34,7 +35,7 @@
   <!-- Nodelet version of kinect2_bridge -->
   <node pkg="nodelet" type="nodelet" name="$(arg base_name)_bridge" machine="$(arg machine)"
         args="load kinect2_bridge/kinect2_bridge_nodelet $(arg nodelet_manager)"
-        respawn="$(arg respawn)" output="screen" if="$(arg use_nodelet)">
+        respawn="$(arg respawn)" output="$(arg screen)" if="$(arg use_nodelet)">
     <param name="base_name"         type="str"    value="$(arg base_name)"/>
     <param name="sensor"            type="str"    value="$(arg sensor)"/>
     <param name="publish_tf"        type="bool"   value="$(arg publish_tf)"/>
@@ -58,7 +59,7 @@
 
   <!-- Node version of kinect2_bridge -->
   <node pkg="kinect2_bridge" type="kinect2_bridge" name="$(arg base_name)_bridge" machine="$(arg machine)"
-        respawn="$(arg respawn)" output="screen" unless="$(arg use_nodelet)">
+        respawn="$(arg respawn)" output="$(arg screen)" unless="$(arg use_nodelet)">
     <param name="base_name"         type="str"    value="$(arg base_name)"/>
     <param name="sensor"            type="str"    value="$(arg sensor)"/>
     <param name="publish_tf"        type="bool"   value="$(arg publish_tf)"/>


### PR DESCRIPTION
This PR adds an argument to the kinect2_bridge launch file to allow control of the node outputs either to screen or to log. Useful if you're including this file in another one and want to suppress the output easily.

Otherwise regular users shouldn't see a difference.