### PR TITLE
Add KDE depth unwrapping support

### DIFF
--- a/kinect2_bridge/README.md
+++ b/kinect2_bridge/README.md
@@ -128,7 +128,7 @@ png_level:=<int>
     info:    PNG compression level from 0 to 9
 depth_method:=<string>
     default: cuda
-    info:    Use specific depth processing: default, cpu, opengl, opencl, cuda
+    info:    Use specific depth processing: default, cpu, opengl, opencl, cuda, clkde, cudakde
 depth_device:=<int>
     default: -1
     info:    openCL device to use for depth processing

--- a/kinect2_bridge/src/kinect2_bridge.cpp
+++ b/kinect2_bridge/src/kinect2_bridge.cpp
@@ -421,6 +421,24 @@ private:
       return false;
 #endif
     }
+    else if(method == "clkde")
+    {
+#ifdef LIBFREENECT2_WITH_OPENCL_SUPPORT
+      packetPipeline = new libfreenect2::OpenCLKdePacketPipeline(device);
+#else
+      OUT_ERROR("OpenCL depth processing is not available!");
+      return false;
+#endif
+    }
+    else if(method == "cudakde")
+    {
+#ifdef LIBFREENECT2_WITH_CUDA_SUPPORT
+      packetPipeline = new libfreenect2::CudaKdePacketPipeline(device);
+#else
+      OUT_ERROR("Cuda depth processing is not available!");
+      return false;
+#endif
+    }
     else
     {
       OUT_ERROR("Unknown depth processing method: " << method);

--- a/kinect2_bridge/src/kinect2_bridge.cpp
+++ b/kinect2_bridge/src/kinect2_bridge.cpp
@@ -1549,6 +1549,7 @@ void help(const std::string &path)
 #endif
 #ifdef LIBFREENECT2_WITH_CUDA_SUPPORT
   depthMethods += ", cuda";
+  depthMethods += ", cudakde";
   depthDefault = "cuda";
 #endif
 #ifdef DEPTH_REG_CPU
@@ -1556,6 +1557,7 @@ void help(const std::string &path)
 #endif
 #ifdef DEPTH_REG_OPENCL
   regMethods += ", opencl";
+  regMethods += ", clkde";
   regDefault = "opencl";
 #endif
 


### PR DESCRIPTION
Hi, this is a trivial PR to add support to the newly added KDE depth unwrapping introduced in libfreenect2: https://github.com/OpenKinect/libfreenect2/commit/ff7ae0bdaed772fcabf0fb687341e863deae4be9

The only issue is that compilation will break if libfreenect2 isn't up-to-date. However, there is no versioning support so I don't see an easy way around this.

Best, Tobias