### PR TITLE
related to: Unable to compile anymore #377 - fixes bug to compile it with opencv 3.2.0

### DIFF
--- a/kinect2_registration/CMakeLists.txt
+++ b/kinect2_registration/CMakeLists.txt
@@ -63,7 +63,7 @@ if(OpenCL_FOUND)
     # Major Linux distro stable releases have buggy OpenCL ICD loader.
     # The workaround of disabling exceptions can only be set up during compile time.
     # Diabling it for all should be harmless. The flag is the same for GCC/Clang/ICC.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+
   endif()
   include_directories(${OpenCL_INCLUDE_DIRS})
 


### PR DESCRIPTION
fixes the compile error:
/opt/ros/kinetic/include/opencv-3.2.0-dev/opencv2/flann/saving.h:113:63: error: exception handling disabled, use -fexceptions to enable
         throw FLANNException("Invalid index file, cannot read");