### PR TITLE
Fixed issue with FLANN exceptions and 16.04

### DIFF
--- a/kinect2_registration/CMakeLists.txt
+++ b/kinect2_registration/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 if(OpenCL_FOUND)
   message(STATUS "OpenCL based depth registration enabled")
   set(EXPORTED_DEPENDENCIES OpenCL)
+  add_definitions( -fexceptions )
 
   if(UNIX AND NOT APPLE)
     include(CheckOpenCLICDLoader)


### PR DESCRIPTION
Without this change, iai_kinect2 won't compile on 16.04 because of an exception that FLANN throws. 