### PR TITLE
Fix compile error in OpenCL shader

### DIFF
--- a/kinect2_registration/src/depth_registration.cl
+++ b/kinect2_registration/src/depth_registration.cl
@@ -187,7 +187,7 @@ void kernel remapDepth(global const ushort *in, global ushort *out, global const
   }
 
   const float4 distXY = (float4)((x - xL) * (x - xL), (xH - x) * (xH - x), (y - yL) * (y - yL), (yH - y) * (yH - y));
-  const float4 tmp = (float4)(sqrt(2.0));
+  const float4 tmp = (float4)(sqrt(2.0f));
   const float4 dist2 = (float4)(distXY.s0 + distXY.s2, distXY.s1 + distXY.s2, distXY.s0 + distXY.s3, distXY.s1 + distXY.s3);
   const float4 dist = select((float4)(0), tmp - sqrt(dist2), valid);
   const float sum = dist.s0 + dist.s1 + dist.s2 + dist.s3;

--- a/kinect2_registration/src/depth_registration.cl
+++ b/kinect2_registration/src/depth_registration.cl
@@ -111,7 +111,7 @@ void kernel checkDepth(global const int4 *idx, global const ushort *zImg, global
 
   const int4 index = idx[i];
   const ushort zI = zImg[i];
-  const ushort thres = 0.01 * zI;
+  const ushort thres = 0.01f * zI;
   const ushort zIThres = zI + thres;
   const float4 dist2 = dists[i];
 
@@ -176,7 +176,7 @@ void kernel remapDepth(global const ushort *in, global ushort *out, global const
   }
 
   const float avg = (p.s0 + p.s1 + p.s2 + p.s3) / count;
-  const float thres = 0.01 * avg;
+  const float thres = 0.01f * avg;
   valid = isless(fabs(p - avg), (float4)(thres));
   count = abs(valid.s0 + valid.s1 + valid.s2 + valid.s3);
 
@@ -187,7 +187,7 @@ void kernel remapDepth(global const ushort *in, global ushort *out, global const
   }
 
   const float4 distXY = (float4)((x - xL) * (x - xL), (xH - x) * (xH - x), (y - yL) * (y - yL), (yH - y) * (yH - y));
-  const float4 tmp = (float4)(sqrt(2.0));
+  const float4 tmp = (float4)(sqrt(2.0f));
   const float4 dist2 = (float4)(distXY.s0 + distXY.s2, distXY.s1 + distXY.s2, distXY.s0 + distXY.s3, distXY.s1 + distXY.s3);
   const float4 dist = select((float4)(0), tmp - sqrt(dist2), valid);
   const float sum = dist.s0 + dist.s1 + dist.s2 + dist.s3;


### PR DESCRIPTION
On a fresh install of Beignet on Ubuntu 18.04, I get an "ambiguous function" OpenCL compile error when running the kinec2 depth registration node.

This compile error happens because there are multiple available sqrt() functions which take a variety of inputs. Since the type of the input data is not explicit, the compile fails.

The fix is to explicitly mark the constant value as a float so the OpenCL compiler can pick the correct version of the sqrt() function. 